### PR TITLE
add a mask creating tool

### DIFF
--- a/tools/create_mask/README.md
+++ b/tools/create_mask/README.md
@@ -1,0 +1,71 @@
+
+# Mask Creating Tool
+
+This tool processes images for creating DiffSTE samples using the Doctr library. It detects text regions in an image, randomly crops these regions, and saves the cropped images along with their masks.
+
+## Features
+
+- Allows configuration of various parameters via command-line arguments.
+- Well suited for documents.
+
+## Requirements
+
+- Python (tested on 3.10)
+- OpenCV
+- NumPy
+- Matplotlib
+- Doctr
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the script with the required parameters:
+
+```bash
+python main.py --input_image /path/to/image.jpg --output_dir /path/to/output/dir
+```
+
+You can also specify additional parameters as needed:
+
+```bash
+python main.py --input_image /path/to/image.jpg --output_dir /path/to/output/dir --arch db_resnet50 --batch_size 4 --bin_thresh 0.5 --device cuda
+```
+
+### Command-Line Arguments
+
+- `--input_image`: Path to the input image (required).
+- `--output_dir`: Directory to save the output images (required).
+- `--arch`: Model architecture (default: `db_resnet50`).
+- `--pretrained`: Use pretrained model (default: `True`).
+- `--pretrained_backbone`: Use pretrained backbone (default: `True`).
+- `--batch_size`: Batch size for the model (default: `2`).
+- `--assume_straight_pages`: Assume straight pages (default: `False`).
+- `--preserve_aspect_ratio`: Preserve aspect ratio (default: `False`).
+- `--symmetric_pad`: Use symmetric padding (default: `True`).
+- `--bin_thresh`: Binarization threshold for postprocessor (default: `0.3`).
+- `--device`: Device to use for computation, e.g., "cuda" or "cpu" (default: `cuda`).
+
+## Acknowledgements
+
+This tool uses the [Doctr](https://github.com/mindee/doctr) project for document text detection. 
+
+### Citation
+
+```bibtex
+@misc{doctr2021,
+    title={docTR: Document Text Recognition},
+    author={Mindee},
+    year={2021},
+    publisher = {GitHub},
+    howpublished = {\url{https://github.com/mindee/doctr}}
+}
+```
+
+## Contributing
+
+Contributions are welcome! Please open an issue or submit a pull request for any improvements or bug fixes.

--- a/tools/create_mask/main.py
+++ b/tools/create_mask/main.py
@@ -1,0 +1,109 @@
+import os
+import argparse
+
+import cv2
+import numpy as np
+from matplotlib import pyplot as plt
+
+from doctr.io import DocumentFile  # type: ignore
+from doctr.models import detection_predictor  # type: ignore
+
+
+def plot(image, si=[12, 12]):
+    fig, ax = plt.subplots(figsize=si)
+    ax.imshow(image, cmap='gray')
+    ax.get_xaxis().set_visible(False)
+    ax.get_yaxis().set_visible(False)
+    plt.show()
+
+
+def crop(img, cxcy, crop_size=256):
+    H, W, _ = img.shape
+    cx, cy = cxcy
+    half_crop_size = crop_size // 2
+
+    # Calculate the top-left and bottom-right corners of the crop
+    x1 = max(cx - half_crop_size, 0)
+    y1 = max(cy - half_crop_size, 0)
+    x2 = min(cx + half_crop_size, W)
+    y2 = min(cy + half_crop_size, H)
+
+    # Adjust the corners if the crop size is smaller than 255x255 pixels
+    if x2 - x1 < crop_size:
+        if x1 == 0:
+            x2 = min(crop_size, W)
+        else:
+            x1 = max(x2 - crop_size, 0)
+
+    if y2 - y1 < crop_size:
+        if y1 == 0:
+            y2 = min(crop_size, H)
+        else:
+            y1 = max(y2 - crop_size, 0)
+
+    # Crop the image
+    cropped_image = img[y1:y2, x1:x2]
+
+    # If the crop is smaller than 255x255, pad it
+    if cropped_image.shape[0] < crop_size or cropped_image.shape[1] < crop_size:
+        padded_image = np.zeros((crop_size, crop_size, 3), dtype=np.uint8)
+        padded_image[:cropped_image.shape[0], :cropped_image.shape[1]] = cropped_image
+        cropped_image = padded_image
+    
+    return cropped_image
+
+
+def main(args):
+    
+    det_predictor = detection_predictor(
+        arch=args.arch, 
+        pretrained=True,
+        pretrained_backbone=True,
+        batch_size=1,
+        assume_straight_pages=False,
+        preserve_aspect_ratio=False,
+        symmetric_pad=True
+    )
+    
+    if args.device == "cuda":
+        det_predictor = det_predictor.cuda().half()
+
+    det_predictor.model.postprocessor.bin_thresh = args.bin_thresh
+    
+    input = DocumentFile.from_images(args.input_image)
+    img = cv2.imread(args.input_image)
+    H, W, _ = img.shape
+    print(f"{H}, {W}")
+    
+    bboxes = det_predictor(input, return_maps=False)[0]['words']
+    bboxes[:, :, 0] *= W
+    bboxes[:, :, 1] *= H
+    bboxes = bboxes.astype(np.int32)
+    
+    idx = np.random.randint(0, len(bboxes), size=1).item()
+    bbox = bboxes[idx]
+    cxcy = np.mean(bbox, axis=0, dtype=np.int32)
+    
+    mask = np.zeros_like(img, dtype=np.uint8)
+    cv2.fillConvexPoly(mask, bbox, [255, 255, 255])
+    
+    imgc = crop(img, cxcy)
+    maskc = crop(mask, cxcy)
+    
+    plot(mask)
+    
+    cv2.imwrite(os.path.join(args.output_dir, "sample.png"), imgc)
+    cv2.imwrite(os.path.join(args.output_dir, "mask.png"), maskc)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Process images for OCR using Doctr.')
+    parser.add_argument('--input_image', type=str, required=True, help='Path to the input image')
+    parser.add_argument('--output_dir', type=str, required=True, help='Directory to save the output images')
+    parser.add_argument('--arch', type=str, default='db_resnet50', help='Model architecture')
+    parser.add_argument('--batch_size', type=int, default=2, help='Batch size for the model')
+    parser.add_argument('--bin_thresh', type=float, default=0.3, help='Binarization threshold for postprocessor')
+    parser.add_argument('--device', type=str, default='cuda', help='Device to use for computation (e.g., "cuda" or "cpu")')
+
+    args = parser.parse_args()
+    main(args)

--- a/tools/create_mask/requirements.txt
+++ b/tools/create_mask/requirements.txt
@@ -1,0 +1,4 @@
+opencv-python==4.9.0.80
+numpy==1.26.4
+matplotlib==3.8.2
+python-doctr[torch]


### PR DESCRIPTION
Thanks for your work. This is a good researcher.
I would like to make my small contribution by adding a tool for generating pairs of masks and images to make it easier for users to prepare their own samples for inference.

The tool detects text regions in an image, randomly crops a region, and saves a cropped image along with its mask. It is designed to be configurable via command-line arguments, providing flexibility and ease of use.